### PR TITLE
Remove reflection from register method

### DIFF
--- a/example/src/main/java/net/idik/lib/slimadapter/example/MainActivity.java
+++ b/example/src/main/java/net/idik/lib/slimadapter/example/MainActivity.java
@@ -40,7 +40,7 @@ public class MainActivity extends AppCompatActivity {
         recyclerView = (RecyclerView) findViewById(R.id.recyler_view);
         recyclerView.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false));
         SlimAdapter.create()
-                .register(R.layout.item_user, new SlimInjector<User>() {
+                .register(R.layout.item_user, User.class, new SlimInjector<User>() {
                     @Override
                     public void onInject(User data, IViewInjector injector) {
                         injector.text(R.id.name, data.getName())
@@ -49,14 +49,14 @@ public class MainActivity extends AppCompatActivity {
                                 .textSize(R.id.age, 8);
                     }
                 })
-                .register(R.layout.item_interger, new SlimInjector<Integer>() {
+                .register(R.layout.item_interger, Integer.class, new SlimInjector<Integer>() {
                     @Override
                     public void onInject(Integer data, IViewInjector injector) {
                         injector.text(R.id.text, data.toString());
 
                     }
                 })
-                .register(R.layout.item_string, new SlimInjector<String>() {
+                .register(R.layout.item_string, String.class, new SlimInjector<String>() {
                     @Override
                     public void onInject(String data, IViewInjector injector) {
                         injector.text(R.id.text, data);

--- a/example/src/main/java/net/idik/lib/slimadapter/example/MainActivity.java
+++ b/example/src/main/java/net/idik/lib/slimadapter/example/MainActivity.java
@@ -64,7 +64,7 @@ public class MainActivity extends AppCompatActivity {
                 })
                 .registerDefault(R.layout.item_string, new SlimInjector() {
                     @Override
-                    public void onInject(Object data, IViewInjector injector) {
+                    public void onInject(Object data, final IViewInjector injector) {
                         injector.text(R.id.text, data.toString())
                                 .longClicked(R.id.text, new View.OnLongClickListener() {
                                     @Override
@@ -82,6 +82,7 @@ public class MainActivity extends AppCompatActivity {
                                     @Override
                                     public void onClick(View v) {
                                         Toast.makeText(MainActivity.this, "DEFAULT INJECT", Toast.LENGTH_LONG).show();
+                                        injector.notifyDataSetChanged();
                                     }
                                 });
 

--- a/exampleforkotlin/src/main/java/net/idik/lib/slimadapter/exampleforkotlin/MainActivity.kt
+++ b/exampleforkotlin/src/main/java/net/idik/lib/slimadapter/exampleforkotlin/MainActivity.kt
@@ -1,14 +1,12 @@
 package net.idik.lib.slimadapter.exampleforkotlin
 
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
-import android.support.annotation.IntegerRes
+import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.widget.Toast
 import net.idik.lib.slimadapter.SlimAdapter
-
-import java.util.ArrayList
+import java.util.*
 
 class MainActivity : AppCompatActivity() {
     private val recyclerView: RecyclerView by lazy<RecyclerView> {
@@ -19,17 +17,17 @@ class MainActivity : AppCompatActivity() {
 
     private val adapter by lazy {
         SlimAdapter.create()
-                .register<String>(R.layout.item_string) { data, injector ->
+                .register<String>(R.layout.item_string, String::class.java) { data, injector ->
                     injector.text(R.id.text, data)
                 }
-                .register<User>(R.layout.item_user) { data, injector ->
+                .register<User>(R.layout.item_user, User::class.java) { data, injector ->
                     injector.text(R.id.name, data.name)
                             .text(R.id.age, data.age.toString())
                             .clicked(R.id.name) {
                                 Toast.makeText(this@MainActivity, "click user name", Toast.LENGTH_LONG).show()
                             }
                 }
-                .register<Int>(R.layout.item_interger) { data, injector ->
+                .register<Int>(R.layout.item_interger, Int::class.java) { data, injector ->
                     injector.text(R.id.text, data.toString())
                             .longClicked(R.id.text) {
                                 Toast.makeText(this@MainActivity, "longclick int", Toast.LENGTH_LONG).show()

--- a/slimadapter/src/main/java/net/idik/lib/slimadapter/AbstractSlimAdapter.java
+++ b/slimadapter/src/main/java/net/idik/lib/slimadapter/AbstractSlimAdapter.java
@@ -10,7 +10,7 @@ abstract class AbstractSlimAdapter extends RecyclerView.Adapter<SlimViewHolder> 
 
     @Override
     public final void onBindViewHolder(SlimViewHolder holder, int position) {
-        holder.bind(getItem(position));
+        holder.bind(getItem(position), this);
     }
 
     protected abstract Object getItem(int position);

--- a/slimadapter/src/main/java/net/idik/lib/slimadapter/SlimAdapter.java
+++ b/slimadapter/src/main/java/net/idik/lib/slimadapter/SlimAdapter.java
@@ -5,7 +5,6 @@ import android.view.ViewGroup;
 
 import net.idik.lib.slimadapter.viewinjector.IViewInjector;
 
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -89,8 +88,7 @@ public class SlimAdapter extends AbstractSlimAdapter {
         return this;
     }
 
-    public <T> SlimAdapter register(final int layoutRes, final SlimInjector<T> slimInjector) {
-        Type type = ((ParameterizedType) slimInjector.getClass().getGenericInterfaces()[0]).getActualTypeArguments()[0];
+    public <T> SlimAdapter register(final int layoutRes, Class<T> type, final SlimInjector<T> slimInjector) {
         creators.put(type, new IViewHolderCreator<T>() {
             @Override
             public SlimTypeViewHolder<T> create(ViewGroup parent) {

--- a/slimadapter/src/main/java/net/idik/lib/slimadapter/SlimViewHolder.java
+++ b/slimadapter/src/main/java/net/idik/lib/slimadapter/SlimViewHolder.java
@@ -29,9 +29,9 @@ public abstract class SlimViewHolder<D> extends RecyclerView.ViewHolder {
         viewMap = new SparseArray<>();
     }
 
-    final void bind(D data) {
+    final void bind(D data, RecyclerView.Adapter adapter) {
         if (injector == null) {
-            injector = new DefaultViewInjector(this);
+            injector = new DefaultViewInjector(this, adapter);
         }
         onBind(data, injector);
     }

--- a/slimadapter/src/main/java/net/idik/lib/slimadapter/viewinjector/DefaultViewInjector.java
+++ b/slimadapter/src/main/java/net/idik/lib/slimadapter/viewinjector/DefaultViewInjector.java
@@ -176,13 +176,13 @@ public class DefaultViewInjector implements IViewInjector<DefaultViewInjector> {
     }
 
     @Override
-    public DefaultViewInjector clickedHolder(View.OnClickListener listener) {
+    public DefaultViewInjector clicked(View.OnClickListener listener) {
         viewHolder.itemView.setOnClickListener(listener);
         return this;
     }
 
     @Override
-    public DefaultViewInjector longClickedHolder(View.OnLongClickListener listener) {
+    public DefaultViewInjector longClicked(View.OnLongClickListener listener) {
         viewHolder.itemView.setOnLongClickListener(listener);
         return this;
     }

--- a/slimadapter/src/main/java/net/idik/lib/slimadapter/viewinjector/DefaultViewInjector.java
+++ b/slimadapter/src/main/java/net/idik/lib/slimadapter/viewinjector/DefaultViewInjector.java
@@ -22,14 +22,18 @@ import net.idik.lib.slimadapter.SlimViewHolder;
  */
 public class DefaultViewInjector implements IViewInjector<DefaultViewInjector> {
 
-    private SlimViewHolder viewHolder;
+    private final SlimViewHolder viewHolder;
 
-    public DefaultViewInjector(SlimViewHolder viewHolder) {
+    private final RecyclerView.Adapter recyclerViewAdapter;
+
+    public DefaultViewInjector(SlimViewHolder viewHolder, RecyclerView.Adapter recyclerViewAdapter) {
         this.viewHolder = viewHolder;
+        this.recyclerViewAdapter = recyclerViewAdapter;
     }
 
     @Override
     public final <T extends View> T findViewById(int id) {
+        //noinspection unchecked
         return (T) viewHolder.id(id);
     }
 
@@ -172,6 +176,18 @@ public class DefaultViewInjector implements IViewInjector<DefaultViewInjector> {
     }
 
     @Override
+    public DefaultViewInjector clickedHolder(View.OnClickListener listener) {
+        viewHolder.itemView.setOnClickListener(listener);
+        return this;
+    }
+
+    @Override
+    public DefaultViewInjector longClickedHolder(View.OnLongClickListener listener) {
+        viewHolder.itemView.setOnLongClickListener(listener);
+        return this;
+    }
+
+    @Override
     public DefaultViewInjector enable(int id, boolean enable) {
         findViewById(id).setEnabled(enable);
         return this;
@@ -256,6 +272,12 @@ public class DefaultViewInjector implements IViewInjector<DefaultViewInjector> {
     public DefaultViewInjector removeView(int id, View view) {
         ViewGroup viewGroup = findViewById(id);
         viewGroup.removeView(view);
+        return this;
+    }
+
+    @Override
+    public DefaultViewInjector notifyDataSetChanged() {
+        recyclerViewAdapter.notifyDataSetChanged();
         return this;
     }
 }

--- a/slimadapter/src/main/java/net/idik/lib/slimadapter/viewinjector/IViewInjector.java
+++ b/slimadapter/src/main/java/net/idik/lib/slimadapter/viewinjector/IViewInjector.java
@@ -56,9 +56,9 @@ public interface IViewInjector<VI extends IViewInjector> {
 
     VI longClicked(int id, View.OnLongClickListener listener);
 
-    VI clickedHolder(View.OnClickListener listener);
+    VI clicked(View.OnClickListener listener);
 
-    VI longClickedHolder(View.OnLongClickListener listener);
+    VI longClicked(View.OnLongClickListener listener);
 
     VI enable(int id, boolean enable);
 

--- a/slimadapter/src/main/java/net/idik/lib/slimadapter/viewinjector/IViewInjector.java
+++ b/slimadapter/src/main/java/net/idik/lib/slimadapter/viewinjector/IViewInjector.java
@@ -56,6 +56,10 @@ public interface IViewInjector<VI extends IViewInjector> {
 
     VI longClicked(int id, View.OnLongClickListener listener);
 
+    VI clickedHolder(View.OnClickListener listener);
+
+    VI longClickedHolder(View.OnLongClickListener listener);
+
     VI enable(int id, boolean enable);
 
     VI enable(int id);
@@ -82,4 +86,6 @@ public interface IViewInjector<VI extends IViewInjector> {
     VI removeAllViews(int id);
 
     VI removeView(int id, View view);
+
+    VI notifyDataSetChanged();
 }


### PR DESCRIPTION
Great library! Unfortunately, this line:

`Type type = ((ParameterizedType) slimInjector.getClass().getGenericInterfaces()[0]).getActualTypeArguments()[0];`

doesn't work when I use retrolambda in my project. Exception:

`java.lang.ClassCastException: java.lang.Class cannot be cast to java.lang.reflect.ParameterizedType
                                                                            at net.idik.lib.slimadapter.SlimAdapter.register(SlimAdapter.java:93)`

The solution is remove reflection and pass a type as parameter.