### PR TITLE
ParametersAreNonnullByDefault

### DIFF
--- a/slimadapter/build.gradle
+++ b/slimadapter/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     })
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:recyclerview-v7:25.3.1'
+    provided 'com.google.code.findbugs:jsr305:3.0.2'
+
 }
 repositories {
     mavenCentral()

--- a/slimadapter/src/main/java/net/idik/lib/slimadapter/package-info.java
+++ b/slimadapter/src/main/java/net/idik/lib/slimadapter/package-info.java
@@ -1,0 +1,2 @@
+@javax.annotation.ParametersAreNonnullByDefault
+package net.idik.lib.slimadapter;


### PR DESCRIPTION
Hello, `SlimAdapter` is awesome, but when using it from Kotlin, I have to specify each time wether the type is nullable or not. Could the square's solution be implemented?

https://medium.com/square-corner-blog/non-null-is-the-default-58ffc0bb9111

This PR is just a starting point, I did not an extensive research of all the functions that should be marked as `@Nullable`